### PR TITLE
Select export type

### DIFF
--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -44,9 +44,9 @@ trait Exportable
      *
      * @return string
      */
-    public function export($path, callable $callback = null)
+    public function export($path, callable $callback = null, $ext = null)
     {
-        self::exportOrDownload($path, 'openToFile', $callback);
+        self::exportOrDownload($path, 'openToFile', $callback, $ext);
 
         return realpath($path) ?: $path;
     }
@@ -62,14 +62,14 @@ trait Exportable
      *
      * @return \Symfony\Component\HttpFoundation\StreamedResponse|string
      */
-    public function download($path, callable $callback = null)
+    public function download($path, callable $callback = null, $ext = null)
     {
         if (method_exists(response(), 'streamDownload')) {
             return response()->streamDownload(function () use ($path, $callback) {
                 self::exportOrDownload($path, 'openToBrowser', $callback);
             }, $path);
         }
-        self::exportOrDownload($path, 'openToBrowser', $callback);
+        self::exportOrDownload($path, 'openToBrowser', $callback, $ext);
 
         return '';
     }
@@ -85,12 +85,12 @@ trait Exportable
      * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      * @throws \OpenSpout\Common\Exception\SpoutException
      */
-    private function exportOrDownload($path, $function, callable $callback = null)
+    private function exportOrDownload($path, $function, callable $callback = null, $ext = null)
     {
-        if (Str::endsWith($path, 'csv')) {
+        if (Str::endsWith($path, 'csv') || $ext === 'csv') {
             $options = new \OpenSpout\Writer\CSV\Options();
             $writer = new \OpenSpout\Writer\CSV\Writer($options);
-        } elseif (Str::endsWith($path, 'ods')) {
+        } elseif (Str::endsWith($path, 'ods') || $ext === 'ods') {
             $options = new \OpenSpout\Writer\ODS\Options();
             $writer = new \OpenSpout\Writer\ODS\Writer($options);
         } else {

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -84,7 +84,7 @@ trait Exportable
      * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      * @throws \OpenSpout\Common\Exception\SpoutException
      */
-    private function exportOrDownload($path, $function, callable $callback = null, $ext = null)
+    private function exportOrDownload($path, $function, callable $callback = null)
     {
         if (str_ends_with($path, 'csv')) {
             $options = new \OpenSpout\Writer\CSV\Options();

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -36,6 +36,7 @@ trait Exportable
     /**
      * @param string        $path
      * @param callable|null $callback
+     * @param string        $ext
      *
      * @throws \OpenSpout\Common\Exception\InvalidArgumentException
      * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
@@ -54,6 +55,7 @@ trait Exportable
     /**
      * @param               $path
      * @param callable|null $callback
+     * @param string        $ext
      *
      * @throws \OpenSpout\Common\Exception\InvalidArgumentException
      * @throws \OpenSpout\Common\Exception\UnsupportedTypeException

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -100,7 +100,7 @@ trait Exportable
         $this->setOptions($options);
 
         // extract file type for writing to php://output
-        if (str_starts_with($path,'php://output')) {
+        if (str_starts_with($path, 'php://output')) {
             $path = explode(';', $path)[0];
         }
 

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -100,7 +100,7 @@ trait Exportable
         $this->setOptions($options);
 
         // extract file type for writing to php://output
-        if (str_starts_with($path,'php://export')) {
+        if (str_starts_with($path,'php://output')) {
             $path = explode(';', $path)[0];
         }
 


### PR DESCRIPTION
**Why?**

We want to be able to assert which file type is output, even when using the `php://output` write only I/O stream to stream files.

**What Changed?**

I added a conditional which checks that the export path is `php://output` and strips off a 'sub-parameter' that may be used to infer the output file type.

I refactored to use PHP string methods instead of the Laravel `Str` helpers.

**Discussion**

I don't love this and would rather pass an explicit param to change the file type, but the code standards of the project were strict in not changing the signature of the main methods even a little bit.